### PR TITLE
Fix config typo

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -25,7 +25,7 @@ module.exports = {
 		'react/no-multi-comp': 'off',
 		'react/jsx-one-expression-per-line': 'off',
 		'jsx-a11y/heading-has-content': 'warn',
-		'react/no-array-index-key': 'warn ',
+		'react/no-array-index-key': 'warn',
 		'react/forbid-prop-types': 'warn',
 		'react/require-default-props': 'warn',
 		'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
Typo in config causes the following error:
Configuration for rule "react/no-array-index-key" is invalid:
	Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"warn "').

eslint : 6.1.0
yarn version v1.17.3