### PR TITLE
get rid of the configuration error

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -43,14 +43,7 @@ module.exports = {
 			}
 		],
 		'jsx-a11y/control-has-associated-label': 'warn',
-		'react/jsx-props-no-spreading': [
-			'off',
-			{
-				html: 'enforce',
-				custom: 'enforce',
-				exceptions: []
-			}
-		],
+		'react/jsx-props-no-spreading': 'off',
 		'react/jsx-curly-newline': 'warn'
 	}
 };

--- a/lib/react.js
+++ b/lib/react.js
@@ -44,10 +44,11 @@ module.exports = {
 		],
 		'jsx-a11y/control-has-associated-label': 'warn',
 		'react/jsx-props-no-spreading': [
-			'warn',
+			'off',
 			{
-				html: 'ignore',
-				custom: 'ignore'
+				html: 'enforce',
+				custom: 'enforce',
+				exceptions: []
 			}
 		],
 		'react/jsx-curly-newline': 'warn'


### PR DESCRIPTION
Cannot pass a configuration object that ignores everything and has no exception
https://github.com/yannickcr/eslint-plugin-react/issues/2387